### PR TITLE
Use the Token Hash as Id instead of the Token Object Id, auto create collections

### DIFF
--- a/src/main/java/com/tentixo/CouchbaseBucketDataAccessProvider.java
+++ b/src/main/java/com/tentixo/CouchbaseBucketDataAccessProvider.java
@@ -32,7 +32,7 @@ public final class CouchbaseBucketDataAccessProvider implements BucketDataAccess
     private final CouchbaseBucketDataAccessProvider _configuration;
 
     private static final Marker MASK_MARKER= MarkerFactory.getMarker("MASK");
-    private static final String BUCKET_COLLECTION_NAME = "curity-buckets";
+    public static final String BUCKET_COLLECTION_NAME = "curity-buckets";
     private final CouchbaseExecutor _couchbaseExecutor;
     private final Collection collection;
 

--- a/src/main/java/com/tentixo/CouchbaseSessionDataAccessProvider.java
+++ b/src/main/java/com/tentixo/CouchbaseSessionDataAccessProvider.java
@@ -27,7 +27,7 @@ import java.time.Instant;
 
 public final class CouchbaseSessionDataAccessProvider implements SessionDataAccessProvider {
     private static final Logger _logger = LoggerFactory.getLogger(CouchbaseSessionDataAccessProvider.class);
-    private static final String SESSION_COLLECTION_NAME = "curity-sessions";
+    public static final String SESSION_COLLECTION_NAME = "curity-sessions";
     private final CouchbaseExecutor _couchbaseExecutor;
     private final Collection collection;
 

--- a/src/main/java/com/tentixo/token/CouchbaseDelegationDataAccessProvider.java
+++ b/src/main/java/com/tentixo/token/CouchbaseDelegationDataAccessProvider.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  */
 public final class CouchbaseDelegationDataAccessProvider implements DelegationDataAccessProvider {
     private static final Logger _logger = LoggerFactory.getLogger(CouchbaseDelegationDataAccessProvider.class);
-    private static final String DELEGATION_COLLECTION_NAME = "curity-delegations";
+    public static final String DELEGATION_COLLECTION_NAME = "curity-delegations";
     private final CouchbaseExecutor _couchbaseExecutor;
     private final Scope scope;
     private final com.couchbase.client.java.Collection collection;

--- a/src/main/java/com/tentixo/token/CouchbaseNonceDataAccessProvider.java
+++ b/src/main/java/com/tentixo/token/CouchbaseNonceDataAccessProvider.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 public final class CouchbaseNonceDataAccessProvider implements NonceDataAccessProvider {
     private static final Logger _logger = LoggerFactory.getLogger(CouchbaseNonceDataAccessProvider.class);
-    private static final String NONCE_COLLECTION_NAME = "curity-nonces";
+    public static final String NONCE_COLLECTION_NAME = "curity-nonces";
     private final CouchbaseExecutor _couchbaseExecutor;
     private final Collection collection;
     private final CouchbaseDataAccessProviderConfiguration _configuration;

--- a/src/main/java/com/tentixo/token/CouchbaseTokenDataAccessProvider.java
+++ b/src/main/java/com/tentixo/token/CouchbaseTokenDataAccessProvider.java
@@ -32,7 +32,7 @@ import java.util.List;
 public final class CouchbaseTokenDataAccessProvider implements TokenDataAccessProvider {
 
     private static final Logger _logger = LoggerFactory.getLogger(CouchbaseTokenDataAccessProvider.class);
-    private static final String TOKEN_COLLECTION_NAME = "curity-tokens";
+    public static final String TOKEN_COLLECTION_NAME = "curity-tokens";
     private final CouchbaseExecutor _couchbaseExecutor;
     private final Collection collection;
 
@@ -43,30 +43,26 @@ public final class CouchbaseTokenDataAccessProvider implements TokenDataAccessPr
 
     @Override
     public @Nullable Token getByHash(String tokenHash) {
-        String tokenId = collection.get(tokenHash).contentAs(String.class);
-        return collection.get(tokenId).contentAs(Token.class);
+        return collection.get(tokenHash).contentAs(Token.class);
     }
 
     @Override
     public void create(Token token) {
         long expiration = token.getExpires();
         Instant expInstant = Instant.ofEpochSecond(expiration);
-        collection.insert(token.getId(), token, InsertOptions.insertOptions().expiry(expInstant));
-        collection.insert(token.getTokenHash(), token.getId(), InsertOptions.insertOptions().expiry(expInstant));
+        collection.insert(token.getTokenHash(), token, InsertOptions.insertOptions().expiry(expInstant));
     }
 
     @Override
     public @Nullable String getStatus(String tokenHash) {
-        String tokenId = collection.get(tokenHash).contentAs(String.class);
-        Token token = collection.get(tokenId).contentAs(Token.class);
+        Token token = collection.get(tokenHash).contentAs(Token.class);
         return token.getStatus().toString();
     }
 
     @Override
     public long setStatusByTokenHash(String tokenHash, TokenStatus newStatus) {
         try {
-            String tokenId = collection.get(tokenHash).contentAs(String.class);
-            collection.mutateIn(tokenId, List.of(MutateInSpec.replace("token", newStatus.name())));
+            collection.mutateIn(tokenHash, List.of(MutateInSpec.replace("token", newStatus.name())));
             return 1;
         } catch (CouchbaseException ce) {
             _logger.error(ce.getMessage());


### PR DESCRIPTION
The token object id is null, the primary key is the token hash. Removing the manual secondary index as it's not necessary anymore and using the hash directly instead.